### PR TITLE
fix: use 'laint1' for input codec

### DIFF
--- a/packages/utils/intent-parser/parser.ts
+++ b/packages/utils/intent-parser/parser.ts
@@ -43,7 +43,8 @@ export function compileTriggerMsg(
     let inputs = []
     for (let i = 0; i < ix.input.length; i++) {
       let input = Buffer.from(ix.input[i], 'base64')
-      inputs.push(Buffer.from(replacePlaceholders(input.toString('ascii'), knownVars)))
+      let replacedBytes = replacePlaceholders(input.toString('latin1'), knownVars)
+      inputs.push(Buffer.from(replacedBytes, 'latin1'))
     }
 
     fisQuery.instructions.push(


### PR DESCRIPTION
# Context

I parsed input using ascii codec but for some input (e.g svm account), it could be arbitrary 8-bit chars which should be decoded using `latin1` (8-bit character) instead of ascii (which only has 7-bit chars)

This PR uses latin1 for codec instead of ascii when compiling input schema into sendable trigger message

Using ascii won't preserve original string when decode => encode in some cases