### PR TITLE
feat(intent): render svm acc for fis input

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "grpc-tools": "^1.12.4",
     "grpc-web": "^1.4.2",
     "grpc_tools_node_protoc_ts": "^5.3.3",
+    "handlebars": "^4.7.8",
     "http-status-codes": "^2.3.0",
     "keccak256": "^1.0.6",
     "mocha": "^10.4.0",

--- a/packages/utils/intent-parser/parser.ts
+++ b/packages/utils/intent-parser/parser.ts
@@ -3,7 +3,7 @@ import {
   FISQueryRequest,
   queryActionFromJSON
 } from '../../../chain/flux/astromesh/v1beta1/query'
-import { Plane, planeFromJSON } from '../../../chain/flux/astromesh/v1beta1/tx'
+import { planeFromJSON } from '../../../chain/flux/astromesh/v1beta1/tx'
 import { MsgTriggerStrategies } from '../../../chain/flux/strategy/v1beta1/tx'
 import * as Handlebars from 'handlebars'
 import * as web3 from '@solana/web3.js'
@@ -51,8 +51,7 @@ export function compileTriggerMsg(
     for (let i = 0; i < ix.input.length; i++) {
       // parse accounts input for SVM for now
       // we can propagate to other planes when it's needed
-      console.log('input:', ix.input[i])
-      if (ix.plane == Plane.SVM) {
+      if (ix.plane == "SVM") {
         let input = Buffer.from(ix.input[i], 'base64').toString('latin1')
         // only consider template, other stays unchanged
         if (input.startsWith("{{") && input.endsWith("}}")) {
@@ -62,9 +61,8 @@ export function compileTriggerMsg(
             ...defaultConst,
           });
           inputs.push(new web3.PublicKey(result).toBytes())
+          continue
         }
-
-        continue
       }
 
       // do normal parsing to get it backward compatible for now
@@ -73,6 +71,7 @@ export function compileTriggerMsg(
       inputs.push(Buffer.from(replacedBytes, 'latin1'))
     }
 
+    console.log('query inputs', inputs)
     fisQuery.instructions.push(
       FISQueryInstruction.create({
         plane: planeFromJSON(ix.plane.toString()),

--- a/packages/utils/intent-parser/parser.ts
+++ b/packages/utils/intent-parser/parser.ts
@@ -53,6 +53,7 @@ export function compileTriggerMsg(
       // we can propagate to other planes when it's needed
       if (ix.plane == Plane.SVM) {
         let input = Buffer.from(ix.input[i], 'base64').toString('latin1')
+        console.log('input:', input)
         // only consider template, other stays unchanged
         if (input.startsWith("{{") && input.endsWith("}}")) {
           let templateSource = Handlebars.compile(input);

--- a/packages/utils/intent-parser/parser.ts
+++ b/packages/utils/intent-parser/parser.ts
@@ -71,7 +71,6 @@ export function compileTriggerMsg(
       inputs.push(Buffer.from(replacedBytes, 'latin1'))
     }
 
-    console.log('query inputs', inputs)
     fisQuery.instructions.push(
       FISQueryInstruction.create({
         plane: planeFromJSON(ix.plane.toString()),

--- a/packages/utils/intent-parser/parser.ts
+++ b/packages/utils/intent-parser/parser.ts
@@ -3,21 +3,28 @@ import {
   FISQueryRequest,
   queryActionFromJSON
 } from '../../../chain/flux/astromesh/v1beta1/query'
-import { Plane, planeFromJSON, planeToJSON } from '../../../chain/flux/astromesh/v1beta1/tx'
-import {
-  Schema,
-  SchemaFISQuery,
-  SchemaPrompt,
-  StrategyMetadata
-} from '../../../chain/flux/strategy/v1beta1/strategy'
+import { Plane, planeFromJSON } from '../../../chain/flux/astromesh/v1beta1/tx'
 import { MsgTriggerStrategies } from '../../../chain/flux/strategy/v1beta1/tx'
-function replaceTypedPlaceholders(template: string, values: any) {
-  return template.replace(/\${(\w+:\w+)}/g, (_: any, key: string) => values[key] || '')
-}
+import * as Handlebars from 'handlebars'
+import * as web3 from '@solana/web3.js'
 
 function replacePlaceholders(template: string, values: any) {
   return template.replace(/\${(\w+)}/g, (_: any, key: string) => values[key] || '')
 }
+
+Handlebars.registerHelper('decodeBase58', function(base58EncodedString) {
+  return new web3.PublicKey(base58EncodedString).toBytes()
+})
+
+Handlebars.registerHelper('pda', function(...args) {
+  let programId = new web3.PublicKey(args[args.length - 2])
+  let seeds: Uint8Array[] = []
+  for(let i = 0; i<args.length - 2; i++) {
+      seeds.push(args[i])
+  }
+  let pdaResult = web3.PublicKey.findProgramAddressSync(seeds, programId)
+  return pdaResult[0]
+});
 
 /*
   Pending Todo: input address by plane?
@@ -42,6 +49,24 @@ export function compileTriggerMsg(
     // replace vars within queries
     let inputs = []
     for (let i = 0; i < ix.input.length; i++) {
+      // parse accounts input for SVM for now
+      // we can propagate to other planes when it's needed
+      if (ix.plane == Plane.SVM) {
+        let input = Buffer.from(ix.input[i], 'base64').toString('latin1')
+        // only consider template, other stays unchanged
+        if (input.startsWith("{{") && input.endsWith("}}")) {
+          let templateSource = Handlebars.compile(input);
+          const result = templateSource({
+            ...userInput,
+            ...defaultConst,
+          });
+          inputs.push(new web3.PublicKey(result).toBytes())
+        }
+
+        continue
+      }
+
+      // do normal parsing to get it backward compatible for now
       let input = Buffer.from(ix.input[i], 'base64')
       let replacedBytes = replacePlaceholders(input.toString('latin1'), knownVars)
       inputs.push(Buffer.from(replacedBytes, 'latin1'))

--- a/packages/utils/intent-parser/parser.ts
+++ b/packages/utils/intent-parser/parser.ts
@@ -51,9 +51,9 @@ export function compileTriggerMsg(
     for (let i = 0; i < ix.input.length; i++) {
       // parse accounts input for SVM for now
       // we can propagate to other planes when it's needed
+      console.log('input:', ix.input[i])
       if (ix.plane == Plane.SVM) {
         let input = Buffer.from(ix.input[i], 'base64').toString('latin1')
-        console.log('input:', input)
         // only consider template, other stays unchanged
         if (input.startsWith("{{") && input.endsWith("}}")) {
           let templateSource = Handlebars.compile(input);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4332,6 +4332,18 @@ handlebars@4.7.7:
   optionalDependencies:
     uglify-js "^3.1.4"
 
+handlebars@^4.7.8:
+  version "4.7.8"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.8.tgz#41c42c18b1be2365439188c77c6afae71c0cd9e9"
+  integrity sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==
+  dependencies:
+    minimist "^1.2.5"
+    neo-async "^2.6.2"
+    source-map "^0.6.1"
+    wordwrap "^1.0.0"
+  optionalDependencies:
+    uglify-js "^3.1.4"
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -5102,7 +5114,7 @@ napi-wasm@^1.1.0:
   resolved "https://registry.yarnpkg.com/napi-wasm/-/napi-wasm-1.1.3.tgz#7bb95c88e6561f84880bb67195437b1cfbe99224"
   integrity sha512-h/4nMGsHjZDCYmQVNODIrYACVJ+I9KItbG+0si6W/jSjdA9JbWDoU4LLeMXVcEQGHjttI2tuXqDrbGF7qkUHHg==
 
-neo-async@^2.6.0:
+neo-async@^2.6.0, neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==


### PR DESCRIPTION
# Context

Drift intent solver needs input of PDA but we can't let user inject it in input as it's so complex
=> This PR supports calculating svm PDA in the background, base on const vars and input.
Now it's using handlebar, a logic-less render library, schema looks like

```
{{pda "user" (decodeBase58 taker_svm_address) "\0\0" "FLR3mfYrMZUnhqEadNJVwjUhjX8ky9vE9qTtDmkK4vwC"}}
```
---

Actually I considered `eval()` and some logic-less rendering.
Eval is more advanced, flexible but it allows some unsafe function access that can steal user info from webpage, access to network or something else, so I go with logic-less well-known `handlebar` lib for now

We can consider adding more flexible schema as we go

After this we will have PR for astromesh app: https://github.com/FluxAstromeshLabs/flux-astromesh/pull/62/files